### PR TITLE
Fix deployment on release duplication

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,6 +2,8 @@ name: github pages
 
 on:
   release:
+    types:
+      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR fixes unneccesary GitHub Actions deployments upon release "Created" and "Released" hooks:
<img width="949" alt="Screenshot 2020-04-04 at 10 29 19" src="https://user-images.githubusercontent.com/8746283/78419436-269cc380-765f-11ea-98c5-b388e0f9dc9c.png">
